### PR TITLE
Fixed check for existence sortable instance

### DIFF
--- a/assets/js/kv-dynagrid.js
+++ b/assets/js/kv-dynagrid.js
@@ -130,7 +130,7 @@
             });
             $form.find('[data-krajee-sortable]').each(function () {
                 var $el = $(this);
-                if ($el.sortable !== undefined) {
+                if ($el.sortable('instance') !== undefined) {
                     $el.sortable('destroy');
                 }
                 $el.sortable(window[$el.attr('data-krajee-sortable')]);


### PR DESCRIPTION
$el.sortable !== undefined does not check the initialization of sortable. We can get error:

```
Uncaught Error: cannot call methods on sortable prior to initialization; attempted to call method 'destroy'
```