### PR TITLE
Fix unicode problem

### DIFF
--- a/DynaGrid.php
+++ b/DynaGrid.php
@@ -502,7 +502,7 @@ class DynaGrid extends Widget
     protected function matchColumnString($column)
     {
         $matches = [];
-        if (!preg_match('/^([\w\.]+)(:(\w*))?(:(.*))?$/', $column, $matches)) {
+        if (!preg_match('/^([\w\.]+)(:(\w*))?(:(.*))?$/u', $column, $matches)) {
             throw new InvalidConfigException(
                 "Invalid column configuration for '{$column}'. The column must be specified " .
                 "in the format of 'attribute', 'attribute:format' or 'attribute:format: label'."


### PR DESCRIPTION
```php
echo \kartik\dynagrid\DynaGrid::widget([
    'columns'         => ['使用者編號', '姓名'],
    'gridOptions'     => [
        'dataProvider' => $dataProvider,
        'toolbar'      => [
            ['content' => '{dynagrid}'],
            '{export}',
        ],
    ],
    'options'         => [
        'id' => 'demo-grid',
    ],
]);
```

Will appear `Invalid column configuration for '使用者編號'. The column must be specified in the format of 'attribute', 'attribute:format' or 'attribute:format: label'.` error.