### PR TITLE
Add ability to configure db connection component

### DIFF
--- a/DynaGridStore.php
+++ b/DynaGridStore.php
@@ -247,7 +247,8 @@ class DynaGridStore extends Object
             ->select($settings[$col])
             ->from($settings['tableName'])
             ->where([$settings['idAttr'] => $id]);
-        return $query->scalar();
+        // Get data from database connection selected in settings
+        return $query->scalar( Yii::$app->$settings['connection'] );
     }
 
     /**
@@ -288,7 +289,7 @@ class DynaGridStore extends Object
                 Yii::$app->response->cookies->add($cookie);
                 break;
             case Dynagrid::TYPE_DB:
-                $db = Yii::$app->db;
+                
                 if ($this->_isMaster) {
                     extract($this->_module->dbSettings);
                 } else {
@@ -298,6 +299,8 @@ class DynaGridStore extends Object
                  * @var string $tableName
                  * @var string $idAttr
                  */
+                // Select database connection set in settings
+                $db = Yii::$app->$connection;
                 $db->createCommand()->delete($tableName, [$idAttr => $key])->execute();
                 break;
             default:
@@ -324,7 +327,8 @@ class DynaGridStore extends Object
              */
             extract($this->_module->dbSettings);
             $attr = $key === self::STORE_FILTER ? $filterAttr : $sortAttr;
-            $db = Yii::$app->db;
+            // Select database connection set in settings
+            $db = Yii::$app->$connection;
             $db->createCommand()->update($tableName, [$attr => null], [$idAttr => $this->_mstKey])->execute();
             return;
         }
@@ -369,7 +373,6 @@ class DynaGridStore extends Object
                 Yii::$app->response->cookies->add($cookie);
                 break;
             case Dynagrid::TYPE_DB:
-                $db = Yii::$app->db;
                 $key = $this->_isMaster ? $this->_mstKey : $this->_dtlKey;
                 $out = $this->getDataFromDb('idAttr', $key);
                 $filterData = null;
@@ -400,6 +403,7 @@ class DynaGridStore extends Object
                         ];
                     }
                 }
+                $db = Yii::$app->$connection;
                 if ($out != null) {
                     $db->createCommand()->update($tableName, $data, [$idAttr => $key])->execute();
                 } else {
@@ -455,7 +459,7 @@ class DynaGridStore extends Object
                     ->select([$s['idAttr'], $s['nameAttr']])
                     ->from($s['tableName'])
                     ->where([$s['dynaGridIdAttr'] => $this->_mstKey, $s['categoryAttr'] => $cat])
-                    ->all();
+                    ->all( Yii::$app->$s['connection'] );
                 return empty($data) ? [] : ArrayHelper::map($data, $s['idAttr'], $s['nameAttr']);
             default:
                 throw new InvalidConfigException('Unknown storage: ' . $this->storage);

--- a/Module.php
+++ b/Module.php
@@ -190,6 +190,7 @@ class Module extends \kartik\base\Module
     public function initSettings()
     {
         $this->dbSettings += [
+            'connection' => 'db',
             'tableName' => 'tbl_dynagrid',
             'idAttr' => 'id',
             'filterAttr' => 'filter_id',
@@ -197,6 +198,7 @@ class Module extends \kartik\base\Module
             'dataAttr' => 'data'
         ];
         $this->dbSettingsDtl += [
+            'connection' => 'db',
             'tableName' => 'tbl_dynagrid_dtl',
             'idAttr' => 'id',
             'categoryAttr' => 'category',


### PR DESCRIPTION
This small change adds key 'connection' to dynagrid settings.

This key is used in DynaGridStore to get data from selected database.