### PR TITLE
Error correction visible and not visible columns

### DIFF
--- a/src/assets/js/kv-dynagrid.js
+++ b/src/assets/js/kv-dynagrid.js
@@ -125,14 +125,10 @@
         },
         _reset: function () {
             var self = this, $visEl = self.$visibleEl, $hidEl = self.$hiddenEl, $form = self.$form;
-            $visEl.kvHtml5Sortable('destroy');
             $visEl.html(self.visibleContent);
-            $hidEl.kvHtml5Sortable('destroy');
             $hidEl.html(self.hiddenContent);
             self._setColumnKeys();
             self.$formContainer.find('.dynagrid-submit-message').remove();
-            $visEl.kvHtml5Sortable(self.visibleSortableOptions);
-            $hidEl.kvHtml5Sortable(self.hiddenSortableOptions);
             $form.trigger('reset.yiiActiveForm');
             setTimeout(function () {
                 $form.find("select").trigger("change");


### PR DESCRIPTION
Fixed an error found when clicking on the button to restart the visible and not visible columns: **TypeError: options is undefined, can not access property "items" of it**

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-dynagrid/blob/master/CHANGE.md)):

- Deletion of instructions for the destruction of sortable elements of visible and not visible columns.

## Related Issues
If this is related to an existing ticket, include a link to it as well.