### PR TITLE
Update Spanish Translations

### DIFF
--- a/src/messages/es/kvdynagrid.php
+++ b/src/messages/es/kvdynagrid.php
@@ -58,7 +58,7 @@ return [
     'Sort Configuration' => 'Configurar orden',
     'Sort Name' => 'Nombre del orden',
     'Trash' => 'Papelera',
-    'Trashing all personalizations' => 'Elimimar todas las opciones personalizadas',
+    'Trashing all personalizations' => 'Eliminar todas las opciones personalizadas',
     'Visible Columns' => 'Columnas visibles',
     'ascending' => 'Ascendente',
     'descending' => 'Descendente',


### PR DESCRIPTION
In Spanish the word "Trashing" must be translated to "Eliminar" not "Elimimar".

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [X] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-dynagrid/blob/master/CHANGE.md)):

- Proofreading of the word "Trashing"
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.