### PR TITLE
ensure DI support

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,10 @@
 Change Log: `yii2-dynagrid`
 ===========================
 
+## Version 1.5.6
+
+- (bugfix #246): ensure DI support by using Yii::createObject() instead of "new $model"
+
 ## Version 1.5.5
 
 **Date:** 25-Jul-2023.

--- a/src/DynaGrid.php
+++ b/src/DynaGrid.php
@@ -1031,7 +1031,7 @@ class DynaGrid extends Widget
         if ($provider instanceof ActiveDataProvider && $provider->query instanceof ActiveQueryInterface) {
             /** @var ActiveQuery $query */
             $query = $provider->query;
-            $model = new $query->modelClass;
+            $model = Yii::createObject($query->modelClass);
 
             return $model->getAttributeLabel($attribute);
         } elseif ($provider instanceof ActiveDataProvider && $provider->query instanceof QueryInterface) {


### PR DESCRIPTION
replaced "new $query->modelClass" in favour of Yii::createObject() which supports DI.

## Scope
This pull request includes a Bugfix which replaces direct creation of Models with Yii::createObject().

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-dynagrid/blob/master/CHANGE.md)):

- replaced "new $query->modelClass" in favour of Yii::createObject() which supports DI
## Related Issues
#246 